### PR TITLE
Add custom filename support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ FEATURES
     • Minimum duration per block
     • Pause padding for punctuation
 - Copy & Download Options – Copy to clipboard or save .srt directly
+- Custom Filenames – Optional field to name your subtitle file
 - Fixed Layout – Scrollable text area and preview box for consistent UI
 - Refresh Option – “New Script” button resets input instantly
 
@@ -42,6 +43,7 @@ INSTALLATION & USAGE
    chmod 775 srt_files
 
 5. Open index.php in your browser (e.g. http://localhost/ScriptGen/index.php)
+6. (Optional) Enter a custom filename before processing to change the output name
 
 FILE STRUCTURE
 --------------

--- a/generate_srt.php
+++ b/generate_srt.php
@@ -24,7 +24,8 @@ try {
             floatval($data['wpm'] ?? 3),
             floatval($data['min_time'] ?? 1.5),
             floatval($data['punctuation_pad'] ?? 0.5),
-            intval($data['max_length'] ?? 450)
+            intval($data['max_length'] ?? 450),
+            $data['name'] ?? ''
         );
 
         echo cleanOutput([
@@ -49,7 +50,7 @@ try {
     exit;
 }
 
-function processScript($script, $wpm, $minTime, $punctuationPad, $maxLength) {
+function processScript($script, $wpm, $minTime, $punctuationPad, $maxLength, $name = '') {
     if ($wpm < 0.5 || $wpm > 10) throw new Exception('Invalid words per second value');
     if ($minTime < 0.5 || $minTime > 10) throw new Exception('Invalid minimum duration');
     if ($punctuationPad < 0 || $punctuationPad > 2) throw new Exception('Invalid punctuation padding');
@@ -76,7 +77,14 @@ function processScript($script, $wpm, $minTime, $punctuationPad, $maxLength) {
         $index++;
     }
 
-    $filename = 'generated_' . time() . '_' . md5($srt) . '.srt';
+    $safeName = '';
+    if ($name !== '') {
+        $safeName = preg_replace('/[^a-z0-9_-]/i', '_', $name);
+    }
+    if ($safeName === '') {
+        $safeName = 'generated_' . time() . '_' . md5($srt);
+    }
+    $filename = $safeName . '.srt';
     $dir = __DIR__ . '/srt_files';
     if (!is_dir($dir) && !mkdir($dir, 0755, true)) {
         throw new Exception('Could not create output directory');

--- a/index.php
+++ b/index.php
@@ -128,6 +128,9 @@
         <input type="number" id="punctuation_pad" value="0.5" step="0.1" min="0">
       </label>
     </div>
+    <label style="margin-bottom:10px"><small>Filename (optional):</small>
+      <input type="text" id="filename" placeholder="my_subs">
+    </label>
     <textarea id="script" placeholder="Paste your script here..."></textarea>
     <div class="bottom-bar">
       <div>
@@ -153,13 +156,14 @@
   const downloadBtn = document.getElementById("downloadBtn");
   const copyBtn = document.getElementById("copyBtn");
   const copyStatus = document.getElementById("copyStatus");
-  let latestFile = "";function processScript() { const script = document.getElementById("script").value; const wpm = document.getElementById("wpm").value; const min_time = document.getElementById("min_time").value; const punctuation_pad = document.getElementById("punctuation_pad").value;
+  let latestFile = "";function processScript() { const script = document.getElementById("script").value; const wpm = document.getElementById("wpm").value; const min_time = document.getElementById("min_time").value; const punctuation_pad = document.getElementById("punctuation_pad").value; const filename = document.getElementById("filename").value;
 
 const formData = new FormData();
 formData.append("script", script);
 formData.append("wpm", wpm);
 formData.append("min_time", min_time);
 formData.append("punctuation_pad", punctuation_pad);
+formData.append("name", filename);
 formData.append("preview_only", "1");
 
 fetch("generate_srt.php", {


### PR DESCRIPTION
## Summary
- allow specifying a custom filename in the UI
- pass the filename in the POST request
- sanitize the name in `generate_srt.php` and use it when saving
- document custom filenames in README

## Testing
- `php -l generate_srt.php` *(fails: command not found)*
- `php -l index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68625a563bf88326a06fbe3d6440f61b