### PR TITLE
Add MIT license file and link in README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Tarek Tarabichi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Version: 1.3.0
 
 Last Updated: May 2025
 Author: Tarek Tarabichi
-License: MIT
+License: [MIT](LICENSE)
 
 An open-source, browser-based tool to convert scripts into CapCut-compatible .srt subtitle files, optimized for voiceover and text-to-speech clarity.
 
@@ -83,6 +83,10 @@ CREDITS
 -------
 Developed by Tarek Tarabichi
 MIT License – Free to use, modify, and distribute
+
+LICENSE
+-------
+This project is licensed under the [MIT License](LICENSE).
 
 FEEDBACK & CONTRIBUTIONS
 -------------------------


### PR DESCRIPTION
## Summary
- add MIT license text in LICENSE
- reference LICENSE from README

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68625a5aee5c8326a7dd84c60062dc15