### PR TITLE
Add markdown cleanup helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ FEATURES
 - Instant Subtitle Generation – Convert plain scripts into .srt format
 - CapCut Voiceover Compatibility – Auto-splits into 450-character blocks (max 500 safe)
 - Improved Sentence Flow – Breaks only on full stops (.) for natural voiceovers
-- Smart Cleanup – Strips markdown (###, ##, *, **) to prevent speech artifacts
+- Smart Cleanup – Sanitizes scripts with `stripMarkdown()` to remove markdown characters (###, ##, *, **) and prevent speech artifacts
 - Parameter Controls – Customize:
     • Words Per Second (WPS)
     • Minimum duration per block

--- a/generate_srt.php
+++ b/generate_srt.php
@@ -10,6 +10,10 @@ function cleanOutput($data) {
     return json_encode($data, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP);
 }
 
+function stripMarkdown($text) {
+    return preg_replace('/[#*]+/', '', $text);
+}
+
 try {
     if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $input = file_get_contents('php://input');
@@ -55,6 +59,7 @@ function processScript($script, $wpm, $minTime, $punctuationPad, $maxLength, $na
     if ($minTime < 0.5 || $minTime > 10) throw new Exception('Invalid minimum duration');
     if ($punctuationPad < 0 || $punctuationPad > 2) throw new Exception('Invalid punctuation padding');
 
+    $script = stripMarkdown($script);
     $chunks = splitIntoChunks($script, $maxLength);
     if (empty($chunks)) throw new Exception('No valid chunks found in script');
 


### PR DESCRIPTION
## Summary
- sanitize script text using a new `stripMarkdown()` helper
- call the helper before splitting into subtitle chunks
- document the sanitation step in the README feature list

## Testing
- `php -l generate_srt.php`
- `php -S localhost:8080` and `curl -X POST -d "script=Hello *world* #title#.**" http://localhost:8080/generate_srt.php`


------
https://chatgpt.com/codex/tasks/task_e_68625bbcbd3c832696b893916a86877b