### PR TITLE
Add viewport meta tag and body fullscreen style

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,6 +1,7 @@
 <!DOCTYPE html><html lang="en">
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>CapCut SRT Generator - Convert your script to SRT format for easy subtitles in CapCut</title>
   <style>
     * { box-sizing: border-box; }
@@ -10,7 +11,9 @@
       font-family: 'Segoe UI', sans-serif;
       margin: 0;
       padding: 20px;
+      width: 100vw;
       height: 100vh;
+      overflow: hidden;
       display: flex;
       flex-direction: column;
     }


### PR DESCRIPTION
## Summary
- ensure the app scales correctly on mobile by adding a viewport meta tag
- apply full-screen styling for `body` to prevent scrollbars

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68625b6163908326b446084eb152d99d