### PR TITLE
🎨 Palette: CapCut template keyboard accessibility & UI feedback improvements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-03-18 - Missing label fors
 **Learning:** Adding htmlFor to labels matching the input id ensures correct linking for screen readers.
 **Action:** Add `for` attributes to all `label` elements that are missing them, tying them to their respective input fields.
+
+## 2025-04-18 - Interactive Divs & Fitts's Law
+**Learning:** When using `div` elements as custom interactive components (like CapCut template cards), they must have `role="button"`, `tabindex="0"`, and `keydown` event listeners for `Enter` and `Space` to be fully accessible. Furthermore, small click targets for toggles should be expanded using a `<label for="...">` wrapper around adjacent descriptive text.
+**Action:** Always verify keyboard navigability of custom components and convert adjacent descriptive text into `<label>` elements for checkboxes/toggles to increase the clickable area.

--- a/index.php
+++ b/index.php
@@ -1443,28 +1443,28 @@
                   CapCut Mode
                 </span>
               </label>
-              <div class="input-group">
+              <div class="input-group" style="display: flex; align-items: center;">
                 <label class="switch" style="margin: 0;">
                   <input type="checkbox" id="capcutMode">
                   <span class="slider"></span>
                 </label>
-                <span style="margin-left: 12px; color: var(--text-muted); font-size: 0.85rem;">Optimize for CapCut mobile editing</span>
+                <label for="capcutMode" style="margin-left: 12px; color: var(--text-muted); font-size: 0.85rem; cursor: pointer;">Optimize for CapCut mobile editing</label>
               </div>
             </div>
             
             <div class="section-divider" style="margin: 20px 0;">CapCut Templates</div>
             <div class="template-grid">
-              <div class="template-card active" data-template="standard">
+              <div class="template-card active" data-template="standard" tabindex="0" role="button" aria-pressed="true">
                 <span class="template-icon">📝</span>
                 <div class="template-name">Standard</div>
                 <div class="template-desc">Clean, professional subtitles</div>
               </div>
-              <div class="template-card" data-template="social_media">
+              <div class="template-card" data-template="social_media" tabindex="0" role="button" aria-pressed="false">
                 <span class="template-icon">📱</span>
                 <div class="template-name">Social Media</div>
                 <div class="template-desc">Engaging with emojis</div>
               </div>
-              <div class="template-card" data-template="educational">
+              <div class="template-card" data-template="educational" tabindex="0" role="button" aria-pressed="false">
                 <span class="template-icon">🎓</span>
                 <div class="template-name">Educational</div>
                 <div class="template-desc">Informative & clear</div>
@@ -1591,7 +1591,7 @@ The tool will automatically:
         </div>
         
         <div class="preview-container">
-          <div id="previewBox" class="preview-box" contenteditable="false">
+          <div id="previewBox" class="preview-box" contenteditable="false" tabindex="0" aria-label="Generated Subtitles Preview">
             <div class="preview-empty">
               <div class="preview-empty-icon">📋</div>
               <div class="preview-empty-text">Click "Generate SRT" to create your subtitle file</div>
@@ -2106,10 +2106,24 @@ The tool will automatically:
       // Template selection
       const templateCards = document.querySelectorAll('.template-card');
       templateCards.forEach(card => {
-        card.addEventListener('click', () => {
-          templateCards.forEach(c => c.classList.remove('active'));
+        const selectTemplate = () => {
+          templateCards.forEach(c => {
+            c.classList.remove('active');
+            c.setAttribute('aria-pressed', 'false');
+          });
           card.classList.add('active');
+          card.setAttribute('aria-pressed', 'true');
+          updateCapCutPreview();
           showToast(`CapCut template: ${card.querySelector('.template-name').textContent}`, 'capcut');
+        };
+
+        card.addEventListener('click', selectTemplate);
+
+        card.addEventListener('keydown', (e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            selectTemplate();
+          }
         });
       });
       


### PR DESCRIPTION
💡 What: 
- Made CapCut template cards keyboard focusable and selectable with `Enter`/`Space`.
- Improved the clickable area for the CapCut Mode switch by converting descriptive text into a `<label>`.
- Allowed keyboard users to focus and scroll the `.preview-box`.
- Ensured immediate visual UI feedback by updating the preview upon template selection.

🎯 Why: 
- Custom `div` interactive components are inaccessible to keyboard and screen reader users without proper ARIA roles and event listeners.
- Small toggle switches (especially on mobile) violate Fitts's Law; expanding the hit area to include the descriptive text drastically improves usability.
- Non-interactive scrollable areas must be focusable so keyboard users can scroll their contents.

♿ Accessibility: Added `tabindex`, `role="button"`, and dynamic `aria-pressed` states to template cards. Added `aria-label` to the preview box. Expanded hit target for a form toggle.

---
*PR created automatically by Jules for task [18101387586411732850](https://jules.google.com/task/18101387586411732850) started by @LebToki*