### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal and Arbitrary Directory Creation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Arbitrary Directory Creation & File Write via Path Traversal
+**Vulnerability:** The application allowed users to specify an arbitrary `export_path` which was used to create directories via `mkdir($exportPath, 0755, true)` BEFORE verifying if the path was within the allowed `srt_files` directory scope. Additionally, the subsequent validation allowed paths anywhere within the web root (`/var/www` or `DOCUMENT_ROOT`), leading to Arbitrary File Write.
+**Learning:** Creating directories or performing filesystem actions based on user input before properly resolving and restricting the canonical path to an allowed base directory creates severe security vulnerabilities, including arbitrary directory creation.
+**Prevention:** Always sanitize the input, resolve the canonical path, and verify that it strictly starts with the realpath of the allowed base directory before performing any filesystem operations like `mkdir` or `file_put_contents`.

--- a/generate_srt.php
+++ b/generate_srt.php
@@ -76,8 +76,8 @@ function stripMarkdown($text) {
 function sanitizeFilename($filename, $default = 'script') {
     // Remove any path components
     $filename = basename($filename);
-    // Remove anything except alphanumeric, dash, underscore
-    $filename = preg_replace('/[^a-zA-Z0-9_-]/', '_', $filename);
+    // Remove anything except alphanumeric, dash, underscore, and period
+    $filename = preg_replace('/[^a-zA-Z0-9_.-]/', '_', $filename);
     // Remove duplicate underscores
     $filename = preg_replace('/_+/', '_', $filename);
     // Limit length
@@ -97,42 +97,46 @@ function validateExportPath($exportPath, $defaultDir) {
         ];
     }
     
-    // Resolve the path
-    $realPath = realpath($exportPath);
-    
-    // Security check: ensure path doesn't go outside allowed directories
     $defaultRealPath = realpath($defaultDir);
+    if (!$defaultRealPath) {
+        if (!is_dir($defaultDir)) {
+            mkdir($defaultDir, 0755, true);
+        }
+        $defaultRealPath = realpath($defaultDir);
+    }
+
+    // Sanitize the requested path to prevent directory traversal
+    $safePath = preg_replace('/[^a-zA-Z0-9_\-\/]/', '', $exportPath);
+    $safePath = trim(str_replace('..', '', $safePath), '/');
+
+    $targetPath = $defaultDir . '/' . $safePath;
     
-    if ($realPath === false) {
-        // Try to create the directory if it doesn't exist
-        if (is_writable(dirname($exportPath)) && mkdir($exportPath, 0755, true)) {
-            $realPath = realpath($exportPath);
+    // Ensure path is within allowed scope BEFORE creating it
+    if (!file_exists($targetPath)) {
+        // Only create if we're sure it's inside the default directory
+        if (is_writable(dirname($targetPath))) {
+            @mkdir($targetPath, 0755, true);
         }
     }
     
+    $realPath = realpath($targetPath);
+
     if ($realPath && is_dir($realPath) && is_writable($realPath)) {
-        // Ensure path is within allowed scope (prevent directory traversal)
-        if ($defaultRealPath && strpos($realPath, $defaultRealPath) !== 0 && strpos($realPath, '/var/www') !== 0 && strpos($realPath, $_SERVER['DOCUMENT_ROOT'] ?? '') !== 0) {
-            // Only allow paths within project or web root
+        // Strictly ensure path is within the default directory (no arbitrary /var/www access)
+        if (strpos($realPath, $defaultRealPath) === 0) {
             return [
-                'path' => $defaultDir,
-                'relative' => 'srt_files/',
-                'valid' => true,
-                'warning' => 'Custom path not allowed, using default'
+                'path' => $realPath,
+                'relative' => 'srt_files/' . $safePath,
+                'valid' => true
             ];
         }
-        return [
-            'path' => $realPath,
-            'relative' => $exportPath,
-            'valid' => true
-        ];
     }
     
     return [
         'path' => $defaultDir,
         'relative' => 'srt_files/',
         'valid' => true,
-        'warning' => 'Invalid custom path, using default'
+        'warning' => 'Custom path not allowed, using default'
     ];
 }
 


### PR DESCRIPTION
This PR addresses a critical security vulnerability where arbitrary directory creation and file writing were possible due to path traversal in the `export_path` handling.

**Vulnerability:**
The `validateExportPath` function in `generate_srt.php` took an unsanitized `export_path` from user input and called `mkdir` on it *before* checking if the resolved path fell within the allowed `srt_files` directory scope. Furthermore, the path validation explicitly allowed any path within `/var/www` or `$_SERVER['DOCUMENT_ROOT']`. This allowed an attacker to create directories and write `.srt` files anywhere the PHP process had write access, particularly anywhere within the web root.

**Fix:**
- Rewrote `validateExportPath` to fully sanitize the user input, stripping `..` and strictly enforcing that the target path is a subdirectory of the default `srt_files` directory *before* creating the directory or returning the valid path.
- The path is now strongly verified to be inside the `$defaultDir` bounds, preventing arbitrary file writes outside the intended scope.
- Addressed a functional bug in `sanitizeFilename` where periods were stripped from filenames, which broke the file download functionality. The regex now allows periods, ensuring downloads work securely.

**Additional Changes:**
- Logged this critical finding in `.jules/sentinel.md` as per Sentinel's journal instructions.
- Removed local testing scripts used during verification.

No frontend changes were introduced. Code has been syntax checked with `php -l` and tested for functional correctness.

---
*PR created automatically by Jules for task [16749722831547493799](https://jules.google.com/task/16749722831547493799) started by @LebToki*