### PR TITLE
🎨 Palette: Fix keyboard focus trap in collapsed sections

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2025-04-18 - Interactive Divs & Fitts's Law
 **Learning:** When using `div` elements as custom interactive components (like CapCut template cards), they must have `role="button"`, `tabindex="0"`, and `keydown` event listeners for `Enter` and `Space` to be fully accessible. Furthermore, small click targets for toggles should be expanded using a `<label for="...">` wrapper around adjacent descriptive text.
 **Action:** Always verify keyboard navigability of custom components and convert adjacent descriptive text into `<label>` elements for checkboxes/toggles to increase the clickable area.
+
+## 2025-04-18 - Keyboard Focus in Collapsed Content
+**Learning:** Hiding elements visually with `max-height: 0` and `overflow: hidden` does not remove them from the tab focus order, creating a confusing keyboard navigation experience where focus disappears into hidden content.
+**Action:** Always combine `max-height` transitions with `visibility: hidden; transition: visibility 0s <delay>;` for collapsed states and `visibility: visible; transition: visibility 0s 0s;` for active states to ensure interactive elements inside are properly removed from tab order.

--- a/index.php
+++ b/index.php
@@ -403,7 +403,8 @@
     .collapsible-content {
       max-height: 0;
       overflow: hidden;
-      transition: max-height 0.3s ease-out;
+      visibility: hidden;
+      transition: max-height 0.3s ease-out, visibility 0s linear 0.3s;
       background: rgba(0, 0, 0, 0.15);
       border: 1px solid var(--glass-border);
       border-top: none;
@@ -412,6 +413,8 @@
     
     .collapsible-content.active {
       max-height: 500px;
+      visibility: visible;
+      transition: max-height 0.3s ease-out, visibility 0s linear 0s;
     }
     
     .collapsible-body {
@@ -1780,6 +1783,7 @@ The tool will automatically:
         header.setAttribute('role', 'button');
         header.setAttribute('tabindex', '0');
         header.setAttribute('aria-expanded', 'false');
+        header.setAttribute('aria-controls', contentId);
         
         header.addEventListener('keydown', (e) => {
           if (e.key === 'Enter' || e.key === ' ') {


### PR DESCRIPTION
💡 What: Fixed an accessibility issue where interactive elements (inputs, dropdowns) inside collapsed CSS sections were still reachable via keyboard tabbing (focus trap).
🎯 Why: When visually hiding content using `max-height: 0` and `overflow: hidden`, the browser does not remove the elements from the accessibility tree or the sequential focus navigation order. This creates a confusing experience for keyboard and screen reader users, who can focus on invisible items and lose their place on the page. Adding properly transitioned `visibility: hidden` ensures that hidden items cannot be focused.
📸 Before/After: (See Playwright verification video output). Focus skips visually hidden sections entirely.
♿ Accessibility:
- Focus sequence now correctly skips closed collapsible sections.
- Screen readers now correctly read the relationship between the toggle button and its controlled content via `aria-controls`.

---
*PR created automatically by Jules for task [2188643594019388144](https://jules.google.com/task/2188643594019388144) started by @LebToki*