### PR TITLE
🎨 Palette: Enhance inline validation accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-04-18 - Visually Hidden Inputs & Focus Rings
 **Learning:** Visually hiding inputs using `opacity: 0; width: 0; height: 0;` (e.g. for custom toggles like the CapCut switch) completely breaks native focus rings, making them invisible to keyboard users even if `*:focus-visible` is globally defined.
 **Action:** When creating custom styled inputs that hide the native input, always explicitly define focus styles on the adjacent styled element (e.g., `input:focus-visible + .slider`) to restore keyboard accessibility.
+
+## 2025-04-18 - Dynamic ARIA for Inline Validation
+**Learning:** Inline form validation messages injected dynamically must be linked to their inputs using `aria-invalid="true"` and `aria-describedby` so screen readers announce the error when focus remains on or returns to the input.
+**Action:** Whenever implementing `setFieldError` or similar DOM-manipulation validation, dynamically set `aria-invalid` and append the error div's ID to `aria-describedby`, ensuring existing attributes aren't overwritten.

--- a/index.php
+++ b/index.php
@@ -1759,9 +1759,19 @@ The tool will automatically:
       if (!feedback) {
         feedback = document.createElement('div');
         feedback.className = 'invalid-feedback';
+        feedback.id = input.id + '-error';
         group.appendChild(feedback);
       }
       feedback.textContent = message;
+
+      input.setAttribute('aria-invalid', 'true');
+
+      let describedbyAttr = input.getAttribute('aria-describedby') || '';
+      let tokens = describedbyAttr.split(/\s+/).filter(Boolean);
+      if (!tokens.includes(feedback.id)) {
+        tokens.push(feedback.id);
+        input.setAttribute('aria-describedby', tokens.join(' '));
+      }
     }
     
     function clearFieldError(input) {
@@ -1771,6 +1781,22 @@ The tool will automatically:
       group.classList.remove('has-error');
       input.classList.remove('is-invalid');
       input.classList.add('is-valid');
+
+      input.removeAttribute('aria-invalid');
+
+      let feedback = group.querySelector('.invalid-feedback');
+      if (feedback) {
+        let describedbyAttr = input.getAttribute('aria-describedby') || '';
+        let tokens = describedbyAttr.split(/\s+/).filter(Boolean);
+        if (tokens.includes(feedback.id)) {
+          let newTokens = tokens.filter(t => t !== feedback.id);
+          if (newTokens.length > 0) {
+            input.setAttribute('aria-describedby', newTokens.join(' '));
+          } else {
+            input.removeAttribute('aria-describedby');
+          }
+        }
+      }
     }
     
     // Collapsible panels


### PR DESCRIPTION
- Added `aria-invalid="true"` to form inputs when they fail validation in `index.php`.
- Safely manage the `aria-describedby` attribute to link the dynamic error message to the input, ensuring existing `aria-describedby` values like tooltips are not overwritten.
- Documented this learning about dynamic ARIA validation in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [369661492768200479](https://jules.google.com/task/369661492768200479) started by @LebToki*